### PR TITLE
Add the ability to specify nested columns paths

### DIFF
--- a/build/griddle.js
+++ b/build/griddle.js
@@ -322,6 +322,15 @@ var Griddle =
 	            });
 	        }
 	    },
+	    grabPath: function(obj, path) {
+	        var pathParts = path.split('.');
+	        var partCount = pathParts.length;
+	        for (var i = 0; i < partCount; i++) {
+	            if(_.isUndefined(obj) || !_.isObject(obj)) return undefined;
+	            obj = obj[pathParts[i]];
+	        }
+	        return obj;
+	    },
 	    getDataForRender: function(data, cols, pageList){
 	        var that = this;
 
@@ -352,7 +361,9 @@ var Griddle =
 	        var transformedData = [];
 
 	        for(var i = 0; i<data.length; i++){
-	            var mappedData = _.pick(data[i], cols.concat(meta));
+	            var mappedData = _.map(cols.concat(meta), function(colPath) {
+	                return that.grabPath(data[i], colPath)
+	            }).filter(function (val) { return !_.isUndefined(val)});
 
 	            if(typeof mappedData[that.props.childrenColumnName] !== "undefined" && mappedData[that.props.childrenColumnName].length > 0){
 	                //internally we're going to use children instead of whatever it is so we don't have to pass the custom name around

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -275,6 +275,15 @@ var Griddle = React.createClass({
             });
         }
     },
+    grabPath: function(obj, path) {
+        var pathParts = path.split('.');
+        var partCount = pathParts.length;
+        for (var i = 0; i < partCount; i++) {
+            if(_.isUndefined(obj) || !_.isObject(obj)) return undefined;
+            obj = obj[pathParts[i]];
+        }
+        return obj;
+    },
     getDataForRender: function(data, cols, pageList){
         var that = this;
 
@@ -305,7 +314,9 @@ var Griddle = React.createClass({
         var transformedData = [];
 
         for(var i = 0; i<data.length; i++){
-            var mappedData = _.pick(data[i], cols.concat(meta));
+            var mappedData = _.map(cols.concat(meta), function(colPath) {
+                return that.grabPath(data[i], colPath)
+            }).filter(function (val) { return !_.isUndefined(val)});
 
             if(typeof mappedData[that.props.childrenColumnName] !== "undefined" && mappedData[that.props.childrenColumnName].length > 0){
                 //internally we're going to use children instead of whatever it is so we don't have to pass the custom name around


### PR DESCRIPTION
This is useful if the JSON API has nested objects. Nested object attributes can be specified with parent.child.attr style strings.