### PR TITLE
Lenient peer dependency on underscore.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pagination",
     "sort"
   ],
-  "main": "modules/griddle.jsx.js",
+  "main": "build/griddle.js",
   "peerDependencies": {
     "react": "~0.12.x",
     "underscore": ">= 1.6.0 < 2"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "modules/griddle.jsx.js",
   "peerDependencies": {
     "react": "~0.12.x",
-    "underscore": "~1.6.0"
+    "underscore": "1.x"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "modules/griddle.jsx.js",
   "peerDependencies": {
     "react": "~0.12.x",
-    "underscore": "1.x"
+    "underscore": ">= 1.6.0 < 2"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
`~1.6.0` rejects underscore v1.7.0. Peer dependencies [need to be lenient](http://blog.nodejs.org/2013/02/07/peer-dependencies/), otherwise this needs to be a f'real dependency, as I understand it.

Updated to `1.x` to allow future versions <2.0.0.