### PR TITLE
Use '...this.props' to simplify passing down props

### DIFF
--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -429,17 +429,29 @@ var Griddle = React.createClass({
         };
     },
     getFilter: function(){
-     return ((this.props.showFilter && this.props.useCustomGridComponent === false) ? 
-        <GridFilter changeFilter={this.setFilter} placeholderText={this.props.filterPlaceholderText} /> : 
+     return ((this.props.showFilter && this.props.useCustomGridComponent === false) ?
+        <GridFilter changeFilter={this.setFilter} placeholderText={this.props.filterPlaceholderText} /> :
         "");
     },
     getSettings: function(){
-        return (this.props.showSettings ? 
-            <button type="button" className={this.props.settingsToggleClassName} onClick={this.toggleColumnChooser} 
-                style={this.props.useGriddleStyles ? { background: "none", border: "none", padding: 0, margin: 0, fontSize: 14} : null}>
-                    {this.props.settingsText}{this.props.settingsIconComponent}
-            </button> : 
-            "");
+      var defaultStyles = {
+        background: "none",
+        border: "none",
+        padding: 0,
+        margin: 0,
+        fontSize: 14
+      };
+
+      return (this.props.showSettings ?
+        <button
+          type="button"
+          className={this.props.settingsToggleClassName}
+          onClick={this.toggleColumnChooser}
+          style={this.props.useGriddleStyles ? defaultStyles : null}
+        >
+          {this.props.settingsText}{this.props.settingsIconComponent}
+        </button> :
+        "");
     },
     getTopSection: function(filter, settings){
         if (this.props.showFilter === false && this.props.showSettings === false){
@@ -473,25 +485,40 @@ var Griddle = React.createClass({
         }
 
         return (
-          <div className="griddle-footer">
-              {this.props.useCustomPagerComponent ?
-                  <CustomPaginationContainer next={this.nextPage} previous={this.previousPage} currentPage={currentPage} maxPage={maxPage} setPage={this.setPage} nextText={this.props.nextText} previousText={this.props.previousText} customPagerComponent={this.props.customPagerComponent}/> :
-                  <GridPagination useGriddleStyles={this.props.useGriddleStyles} next={this.nextPage} previous={this.previousPage} nextClassName={this.props.nextClassName} nextIconComponent={this.props.nextIconComponent} previousClassName={this.props.previousClassName} previousIconComponent={this.props.previousIconComponent} currentPage={currentPage} maxPage={maxPage} setPage={this.setPage} nextText={this.props.nextText} previousText={this.props.previousText}/>
+            <div className="griddle-footer">
+                {this.props.useCustomPagerComponent ?
+                <CustomPaginationContainer
+                    {...this.props}
+                    next={this.nextPage}
+                    previous={this.previousPage}
+                    currentPage={currentPage}
+                    maxPage={maxPage}
+                    setPage={this.setPage}
+                /> :
+                <GridPagination
+                    {...this.props}
+                    next={this.nextPage}
+                    previous={this.previousPage}
+                    currentPage={currentPage}
+                    maxPage={maxPage}
+                    setPage={this.setPage}
+                />
               }
           </div>
         );
     },
     getColumnSelectorSection: function(keys, cols){
         return this.state.showColumnChooser ? (
-          <GridSettings
-            {...this.props}
-            columns={keys}
-            selectedColumns={cols}
-            setColumns={this.setColumns}
-            setPageSize={this.setPageSize}
-            showSetPageSize={!this.props.useCustomGridComponent}
-            toggleCustomComponent={this.toggleCustomComponent}
-            useCustomComponent={this.props.useCustomRowComponent || this.props.useCustomGridComponent} />
+            <GridSettings
+                {...this.props}
+                columns={keys}
+                selectedColumns={cols}
+                setColumns={this.setColumns}
+                setPageSize={this.setPageSize}
+                showSetPageSize={!this.props.useCustomGridComponent}
+                toggleCustomComponent={this.toggleCustomComponent}
+                useCustomComponent={this.props.useCustomRowComponent || this.props.useCustomGridComponent}
+            />
         ) : "";
     },
     getCustomGridSection: function(){

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -483,11 +483,15 @@ var Griddle = React.createClass({
     },
     getColumnSelectorSection: function(keys, cols){
         return this.state.showColumnChooser ? (
-            <GridSettings columns={keys} selectedColumns={cols} setColumns={this.setColumns} settingsText={this.props.settingsText}
-             settingsIconComponent={this.props.settingsIconComponent} maxRowsText={this.props.maxRowsText} setPageSize={this.setPageSize}
-             showSetPageSize={!this.props.useCustomGridComponent} resultsPerPage={this.props.resultsPerPage} enableToggleCustom={this.props.enableToggleCustom}
-             toggleCustomComponent={this.toggleCustomComponent} useCustomComponent={this.props.useCustomRowComponent || this.props.useCustomGridComponent}
-             useGriddleStyles={this.props.useGriddleStyles} enableCustomFormatText={this.props.enableCustomFormatText} columnMetadata={this.props.columnMetadata} />
+          <GridSettings
+            {...this.props}
+            columns={keys}
+            selectedColumns={cols}
+            setColumns={this.setColumns}
+            setPageSize={this.setPageSize}
+            showSetPageSize={!this.props.useCustomGridComponent}
+            toggleCustomComponent={this.toggleCustomComponent}
+            useCustomComponent={this.props.useCustomRowComponent || this.props.useCustomGridComponent} />
         ) : "";
     },
     getCustomGridSection: function(){
@@ -499,17 +503,23 @@ var Griddle = React.createClass({
             style={this.getClearFixStyles()} />{this.props.showPager&&pagingContent}</div>
     },
     getStandardGridSection: function(data, cols, meta, pagingContent, hasMorePages){
-        return (<div className='griddle-body'><GridTable useGriddleStyles={this.props.useGriddleStyles} isSubGriddle={this.props.isSubGriddle}
-              useGriddleIcons={this.props.useGriddleIcons} useFixedLayout={this.props.useFixedLayout} columnMetadata={this.props.columnMetadata}
-              showPager={this.props.showPager} pagingContent={pagingContent} data={data} columns={cols} metadataColumns={meta} className={this.props.tableClassName}
-              enableInfiniteScroll={this.isInfiniteScrollEnabled()} enableSort={this.props.enableSort} nextPage={this.nextPage} changeSort={this.changeSort} sortColumn={this.getCurrentSort()}
-              sortAscending={this.getCurrentSortAscending()} showTableHeading={this.props.showTableHeading} useFixedHeader={this.props.useFixedHeader}
-              sortAscendingClassName={this.props.sortAscendingClassName} sortDescendingClassName={this.props.sortDescendingClassName}
-              parentRowCollapsedClassName={this.props.parentRowCollapsedClassName} parentRowExpandedClassName={this.props.parentRowExpandedClassName}
-              sortAscendingComponent={this.props.sortAscendingComponent} sortDescendingComponent={this.props.sortDescendingComponent}
-              parentRowCollapsedComponent={this.props.parentRowCollapsedComponent} parentRowExpandedComponent={this.props.parentRowExpandedComponent}
-              bodyHeight={this.props.bodyHeight} infiniteScrollSpacerHeight={this.props.infiniteScrollSpacerHeight} externalLoadingComponent={this.props.externalLoadingComponent}
-              externalIsLoading={this.props.externalIsLoading} hasMorePages={hasMorePages} /></div>)
+      return (
+        <div className='griddle-body'>
+          <GridTable
+            {...this.props}
+            pagingContent={pagingContent}
+            data={data}
+            columns={cols}
+            metadataColumns={meta}
+            className={this.props.tableClassName}
+            enableInfiniteScroll={this.isInfiniteScrollEnabled()}
+            nextPage={this.nextPage}
+            changeSort={this.changeSort}
+            sortColumn={this.getCurrentSort()}
+            sortAscending={this.getCurrentSortAscending()}
+            hasMorePages={hasMorePages} />
+        </div>
+      );
     },
     getContentSection: function(data, cols, meta, pagingContent, hasMorePages){
         if(this.props.useCustomGridComponent && this.props.customGridComponent !== null){


### PR DESCRIPTION
React has a `{...this.props}` shortcut to pass down props to other components. I've updated the code to remove some of the unnecessary duplication and simplified some of the prop formatting to be more readable. 

Happy to discuss the pros/cons and update as needed.