### PR TITLE
Add headerClassName and headerStyles props to Griddle and GriddleTitle.

### DIFF
--- a/scripts/gridTitle.jsx
+++ b/scripts/gridTitle.jsx
@@ -17,7 +17,9 @@ var GridTitle = React.createClass({
            "sortDescendingClassName": "sort-descending",
            "sortAscendingComponent": " ▲",
            "sortDescendingComponent": " ▼",
-           "enableSort": true,  
+           "enableSort": true,
+           "headerClassName": "",
+           "headerStyles": "",
            "changeSort": null
         }
     },
@@ -79,7 +81,9 @@ var GridTitle = React.createClass({
 
         return(
             <thead>
-                <tr style={this.titleStyles}>
+                <tr
+                    className={this.props.headerClassName}
+                    style={this.props.headerStyles}>
                     {nodes}
                 </tr>
             </thead>

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -79,6 +79,8 @@ var Griddle = React.createClass({
             "settingsToggleClassName": "settings",
             "nextClassName": "griddle-next",
             "previousClassName": "griddle-previous",
+            "headerClassName": "griddle-header",
+            "headerStyles": {},
             /* icon components */
             "sortAscendingComponent": " ▲",
             "sortDescendingComponent": " ▼",


### PR DESCRIPTION
This should fix #70 as soon as #71 is merged with some minor modifications. I've added a `headerClassName` and `headerStyles` property to Griddle so that someone can override the default header styling. 

Happy to hear feedback on implementation but it's pretty straight forward.