### PR TITLE
Add support for empty columns so items will be rendered under the matching column. 

### DIFF
--- a/build/griddle.js
+++ b/build/griddle.js
@@ -1909,7 +1909,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 	      if (_this.props.columnSettings.hasColumnMetadata() && typeof meta !== "undefined") {
-	        var colData = typeof meta.customComponent === "undefined" || meta.customComponent === null ? col[1] : React.createElement(meta.customComponent, { data: col[1], rowData: dataView });
+	        var colData = typeof meta.customComponent === "undefined" || meta.customComponent === null ? col[1] : React.createElement(meta.customComponent, { data: col[1], rowData: dataView, metadata: meta });
 	        returnValue = meta == null ? returnValue : React.createElement(
 	          "td",
 	          { onClick: _this.props.hasChildren && _this.handleClick, className: meta.cssClassName, key: index, style: columnStyles },

--- a/build/griddle.js
+++ b/build/griddle.js
@@ -1909,7 +1909,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 	      if (_this.props.columnSettings.hasColumnMetadata() && typeof meta !== "undefined") {
-	        var colData = typeof meta.customComponent === "undefined" || meta.customComponent === null ? col[1] : React.createElement(meta.customComponent, { data: col[1], rowData: _this.props.data });
+	        var colData = typeof meta.customComponent === "undefined" || meta.customComponent === null ? col[1] : React.createElement(meta.customComponent, { data: col[1], rowData: dataView });
 	        returnValue = meta == null ? returnValue : React.createElement(
 	          "td",
 	          { onClick: _this.props.hasChildren && _this.handleClick, className: meta.cssClassName, key: index, style: columnStyles },

--- a/build/griddle.js
+++ b/build/griddle.js
@@ -1875,7 +1875,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	      };
 	    }
 
-	    var data = _.pairs(_.pick(this.props.data, this.props.columnSettings.getColumns()));
+	    var columns = this.props.columnSettings.getColumns();
+
+	    // make sure that all the columns we need have default empty values
+	    // otherwise they will get clipped
+	    var defaults = _.object(columns, []);
+
+	    // creates a 'view' on top the data so we will not alter the original data but will allow us to add default values to missing columns
+	    var dataView = Object.create(this.props.data);
+
+	    _.defaults(dataView, defaults);
+
+	    var data = _.pairs(_.pick(dataView, columns));
+
 	    var nodes = data.map(function (col, index) {
 	      var returnValue = null;
 	      var meta = _this.props.columnSettings.getColumnMetadataByName(col[0]);

--- a/examples/infiniteScroll/infiniteScroll.html
+++ b/examples/infiniteScroll/infiniteScroll.html
@@ -1,5 +1,5 @@
 <div id="griddle-infinite-scroll"></div>
 
 <script type="text/jsx">
-  React.render(<Griddle results={fakeData} columnMetadata={columnMeta} resultsPerPage={5} enableInfiniteScroll={true} bodyHeight={400}/>, document.getElementById('griddle-infinite-scroll'));
+  React.render(<Griddle results={fakeData} columnMetadata={columnMeta} rowMetadata={rowMeta} resultsPerPage={5} enableInfiniteScroll={true} bodyHeight={400}/>, document.getElementById('griddle-infinite-scroll'));
 </script>

--- a/examples/infiniteScroll/infiniteScrollFixedHeader.html
+++ b/examples/infiniteScroll/infiniteScrollFixedHeader.html
@@ -1,5 +1,5 @@
 <div id="griddle-infinite-fixed-header"></div>
 
 <script type="text/jsx">
-	React.render(<Griddle results={fakeData} columnMetadata={columnMeta} resultsPerPage={5} enableInfiniteScroll={true} useFixedHeader={true} bodyHeight={400}/>, document.getElementById('griddle-infinite-fixed-header'));
+	React.render(<Griddle results={fakeData} columnMetadata={columnMeta} rowMetadata={rowMeta} resultsPerPage={5} enableInfiniteScroll={true} useFixedHeader={true} bodyHeight={400}/>, document.getElementById('griddle-infinite-fixed-header'));
 </script>

--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -77,7 +77,7 @@ var GridRow = React.createClass({
 
 
             if (this.props.columnSettings.hasColumnMetadata() && typeof meta !== "undefined"){
-              var colData = (typeof meta.customComponent === 'undefined' || meta.customComponent === null) ? col[1] : <meta.customComponent data={col[1]} rowData={dataView} />;
+              var colData = (typeof meta.customComponent === 'undefined' || meta.customComponent === null) ? col[1] : <meta.customComponent data={col[1]} rowData={dataView} metadata={meta} />;
               returnValue = (meta == null ? returnValue : <td onClick={this.props.hasChildren && this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{colData}</td>);
             }
 

--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -48,7 +48,19 @@ var GridRow = React.createClass({
           };
         }
 
-        var data = _.pairs(_.pick(this.props.data, this.props.columnSettings.getColumns()))
+        var columns = this.props.columnSettings.getColumns();
+        
+        // make sure that all the columns we need have default empty values
+        // otherwise they will get clipped
+        var defaults = _.object(columns, []);
+
+        // creates a 'view' on top the data so we will not alter the original data but will allow us to add default values to missing columns
+        var dataView = Object.create(this.props.data);
+
+        _.defaults(dataView, defaults);
+
+        var data = _.pairs(_.pick(dataView, columns));
+        
         var nodes = data.map((col, index) => {
             var returnValue = null;
             var meta = this.props.columnSettings.getColumnMetadataByName(col[0]);

--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -77,7 +77,7 @@ var GridRow = React.createClass({
 
 
             if (this.props.columnSettings.hasColumnMetadata() && typeof meta !== "undefined"){
-              var colData = (typeof meta.customComponent === 'undefined' || meta.customComponent === null) ? col[1] : <meta.customComponent data={col[1]} rowData={this.props.data} />;
+              var colData = (typeof meta.customComponent === 'undefined' || meta.customComponent === null) ? col[1] : <meta.customComponent data={col[1]} rowData={dataView} />;
               returnValue = (meta == null ? returnValue : <td onClick={this.props.hasChildren && this.handleClick} className={meta.cssClassName} key={index} style={columnStyles}>{colData}</td>);
             }
 

--- a/scripts/gridRowContainer.jsx
+++ b/scripts/gridRowContainer.jsx
@@ -68,12 +68,12 @@ var GridRowContainer = React.createClass({
                               showTableHeading={false} showPager={false} columnMetadata={that.props.columnMetadata}
                               parentRowExpandedComponent={that.props.parentRowExpandedComponent}
                               parentRowCollapsedComponent={that.props.parentRowCollapsedComponent}
-                                paddingHeight={that.props.paddingHeight} rowHeight={that.props.rowHeight} />
+                              paddingHeight={that.props.paddingHeight} rowHeight={that.props.rowHeight} />
                           </td>
                         </tr>);
               }
 
-              return <GridRow useGriddleStyles={that.props.useGriddleStyles} isSubGriddle={that.props.isSubGriddle} data={row} columnSettings={that.props.columnSettings} isChildRow={true} columnMetadata={that.props.columnMetadata} key={_.uniqueId("grid_row")}/>
+              return <GridRow useGriddleStyles={that.props.useGriddleStyles} isSubGriddle={that.props.isSubGriddle} data={row} columnSettings={that.props.columnSettings} isChildRow={true} columnMetadata={that.props.columnMetadata} key={that.props.rowSettings.getRowId(row)}/>
           });
       }
 

--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -24,7 +24,7 @@ var Griddle = React.createClass({
         return{
             "columns": [],
             "columnMetadata": [],
-            "rowMetadata": [],
+            "rowMetadata": null,
             "resultsPerPage":5,
             "results": [], // Used if all results are already loaded.
             "initialSort": "",

--- a/scripts/rowProperties.js
+++ b/scripts/rowProperties.js
@@ -1,17 +1,26 @@
-var _ = require('underscore'); 
+var _ = require('underscore');
 
 class RowProperties{
-  constructor (rowMetadata=[]){
+  constructor (rowMetadata={}){
     this.rowMetadata = rowMetadata;
   }
 
   getRowMetadataByName(name){
-    return _.findWhere(this.rowMetadata, {rowName: name}); 
+    return _.findWhere(this.rowMetadata, {rowName: name});
   }
 
   hasRowMetadata(){
-   return this.rowMetadata !== null && this.rowMetadata.length > 0  
+    return this.rowMetadata !== null;
+  }
+
+  getRowId(row, backupId){
+    if(this.hasRowMetadata() && this.rowMetadata.key) {
+      return row[this.rowMetadata.key];
+    } else {
+      console.warn("No row 'key' specified; a generated unique id will be used for each table row (which negatively impacts performance).");
+      return _.uniqueId("grid_row")
+    };
   }
 }
 
-module.exports = RowProperties; 
+module.exports = RowProperties;


### PR DESCRIPTION
Currently missing fields cause the grid to render values in offset under the wrong columns.
This change introduces default empty values for missing columns.

A new slim data view was added which holds default values for any missing columns and does not alter the original data.